### PR TITLE
Add clustering through libcluster

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+elixir 1.11.0-otp-23
+erlang 23.1.1
+

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,6 +1,6 @@
 import Config
 
-hostname = System.fetch_env!("HOSTNAME")
+hostname = System.get_env("HOSTNAME", "localhost")
 
 config :libcluster,
   topologies: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,22 @@
+import Config
+
+hostname = System.fetch_env!("HOSTNAME")
+
+config :libcluster,
+  topologies: [
+    default: [
+      # The selected clustering strategy. Required.
+      strategy: Cluster.Strategy.Epmd,
+      # Configuration for the provided strategy. Optional.
+      config: [hosts: [:"a@#{hostname}", :"b@#{hostname}"]],
+      # The function to use for connecting nodes. The node
+      # name will be appended to the argument list. Optional
+      connect: {:net_kernel, :connect_node, []},
+      # The function to use for disconnecting nodes. The node
+      # name will be appended to the argument list. Optional
+      disconnect: {:erlang, :disconnect_node, []},
+      # The function to use for listing nodes.
+      # This function must return a list of node names. Optional
+      list_nodes: {:erlang, :nodes, [:connected]}
+    ]
+  ]

--- a/lib/notification_dispatcher/application.ex
+++ b/lib/notification_dispatcher/application.ex
@@ -4,6 +4,11 @@ defmodule NotificationDispatcher.Application do
   use Application
 
   def start(_type, _opts) do
-    DynamicSupervisor.start_link(strategy: :one_for_one)
+    Supervisor.start_link(
+    [
+      {Cluster.Supervisor, [Application.fetch_env!(:libcluster, :topologies)]}
+    ],
+    strategy: :one_for_one
+    )
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule NotificationDispatcher.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:broadway, "~> 0.6"}
+      {:broadway, "~> 0.6"},
+      {:libcluster, "~> 3.2.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
   "broadway": {:hex, :broadway, "0.6.2", "ef8e0d257420c72f0e600958cf95556835d9921ad14be333493083226458791a", [:mix], [{:gen_stage, "~> 1.0", [hex: :gen_stage, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "f4f93704304a736c984cd6ed884f697415f68eb50906f4dc5d641926366ad8fa"},
   "gen_stage": {:hex, :gen_stage, "1.0.0", "51c8ae56ff54f9a2a604ca583798c210ad245f415115453b773b621c49776df5", [:mix], [], "hexpm", "1d9fc978db5305ac54e6f5fec7adf80cd893b1000cf78271564c516aa2af7706"},
+  "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
+  "libcluster": {:hex, :libcluster, "3.2.1", "b2cd5b447cde25d5897749bee6f7aaeb6c96ac379481024e9b6ba495dabeb97d", [:mix], [{:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "89f225612d135edce9def56f43bf18d575d88ac4680e3f6161283f2e55cadca4"},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
 }

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,1 @@
+HOSTNAME=$HOSTNAME iex --sname "$1@$HOSTNAME" --cookie "localdev" -S mix


### PR DESCRIPTION
This should allow any clustering strategy to be set from the runtime configs.

Sets a default one (Empd) which will be used in development.